### PR TITLE
add "Toggle Backend APIs" menu item for admins

### DIFF
--- a/.envSample
+++ b/.envSample
@@ -15,7 +15,6 @@ LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 LANGCHAIN_API_KEY=BlahBlahBlah
 DOCKER_REGISTRY=awesome.registry.com
 DOCKER_IMAGE_NAME=wyouradio
-USE_OPENAI_AND_11LABS=true
 
 
 

--- a/client/Components/NavBar.js
+++ b/client/Components/NavBar.js
@@ -1,16 +1,20 @@
-import React, { Component } from "react"
-import Navbar from "react-bootstrap/Navbar"
-import { connect } from "react-redux"
-import { clearUser, showProfile } from "../store/userSlice"
-import { Link } from "react-router-dom"
-import { useNavigate } from "react-router-dom"
-import NavDropdown from "react-bootstrap/NavDropdown"
+import React, { Component } from 'react'
+import Navbar from 'react-bootstrap/Navbar'
+import { connect } from 'react-redux'
+import {
+  clearUser,
+  showProfile,
+  toggleUseBackendApis,
+} from '../store/userSlice'
+import { useNavigate } from 'react-router-dom'
+import NavDropdown from 'react-bootstrap/NavDropdown'
+import Form from 'react-bootstrap/Form'
 
 const NavBar = (props) => {
   const navigate = useNavigate()
 
   return (
-    <Navbar bg="dark" variant="dark" style={{marginTop:"5px !important"}} >
+    <Navbar bg="dark" variant="dark" style={{ marginTop: '5px !important' }}>
       <Navbar.Brand className="ms-3">WYOU Radio</Navbar.Brand>
 
       {props.user && (
@@ -45,6 +49,18 @@ const NavBar = (props) => {
                   Profile
                 </NavDropdown.Item>
               </span>
+              {props.user?.isAdmin ? (
+                <>
+                  <NavDropdown.Divider />
+                  <NavDropdown.Item
+                    onClick={() => props.toggleUseBackendApis()}
+                  >
+                    {props.useBackendApis
+                      ? 'Disable Backend APIs'
+                      : 'Enable Backend APIs'}
+                  </NavDropdown.Item>
+                </>
+              ) : null}
             </NavDropdown>
           </span>
         </>
@@ -55,6 +71,7 @@ const NavBar = (props) => {
 
 const mapStateToProps = (state) => ({
   user: state.user.details,
+  useBackendApis: state.user.useBackendApis,
   currentStation: state.stations.currentStation,
   currentDj: state.djs.currentDj,
 })
@@ -62,6 +79,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = {
   logout: () => clearUser(),
   showProfile: () => showProfile(),
+  toggleUseBackendApis: () => toggleUseBackendApis(),
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(NavBar)

--- a/client/Components/Radio.js
+++ b/client/Components/Radio.js
@@ -163,8 +163,7 @@ export class Radio extends Component {
 
       let dataUri
 
-      const useOpenAIAnd11Labs = process.env.USE_OPENAI_AND_11LABS === 'true'
-      if (useOpenAIAnd11Labs) {
+      if (this.props.useBackendApis) {
         dataUri = await axios.post('/api/content/next-content', payload)
       }
 
@@ -622,6 +621,7 @@ const mapStateToProps = (reduxState) => ({
   currentDj: reduxState.djs.currentDj,
   profile: reduxState.user?.profile,
   isAdmin: reduxState.user?.details?.isAdmin,
+  useBackendApis: reduxState.user.useBackendApis,
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/store/userSlice.js
+++ b/client/store/userSlice.js
@@ -1,15 +1,16 @@
-import { createSlice } from "@reduxjs/toolkit"
-import axios from "axios"
+import { createSlice } from '@reduxjs/toolkit'
+import axios from 'axios'
 
 const initialState = {
   code: null,
   details: null,
   profile: null,
   showProfile: false,
+  useBackendApis: true,
 }
 
 const userSlice = createSlice({
-  name: "user",
+  name: 'user',
   initialState,
   reducers: {
     setUser: (state, action) => {
@@ -33,6 +34,9 @@ const userSlice = createSlice({
     hideProfile: (state, action) => {
       state.showProfile = false
     },
+    toggleUseBackendApis: (state) => {
+      state.useBackendApis = !state.useBackendApis
+    },
   },
 })
 
@@ -44,11 +48,12 @@ export const {
   clearProfile,
   showProfile,
   hideProfile,
+  toggleUseBackendApis,
 } = userSlice.actions
 
 export const fetchProfile = () => async (dispatch) => {
   try {
-    const { data } = await axios.get("api/profile")
+    const { data } = await axios.get('api/profile')
     dispatch(setProfile(data))
   } catch (err) {
     console.log(err)
@@ -57,7 +62,7 @@ export const fetchProfile = () => async (dispatch) => {
 
 export const updateProfile = (profile) => async (dispatch) => {
   try {
-    const { data } = await axios.put("api/profile", profile)
+    const { data } = await axios.put('api/profile', profile)
     dispatch(setProfile(data))
     dispatch(hideProfile())
   } catch (err) {


### PR DESCRIPTION
add "Toggle Backend APIs" menu item for admins
Default for everyone is to have the 11 Labs and OpenAI calls being made.  Admins now have a menu option to disable these to avoid making these calls when working on something else.  This menu option is not visible to normal users.